### PR TITLE
new button order and accept connection description.

### DIFF
--- a/src/Osma.Mobile.App/ViewModels/Connections/AcceptInviteViewModel.cs
+++ b/src/Osma.Mobile.App/ViewModels/Connections/AcceptInviteViewModel.cs
@@ -40,6 +40,7 @@ namespace Osma.Mobile.App.ViewModels.Connections
             {
                 InviteTitle = $"Trust {invite.Label}?";
                 InviterUrl = invite.ImageUrl;
+                InviteContents = $"{invite.Label} would like to establish a pairwise DID connection with you. This will allow secure communication between you and {invite.Label}.";
                 _invite = invite;
             }
             return base.InitializeAsync(navigationData);

--- a/src/Osma.Mobile.App/Views/Connections/AcceptInvitePage.xaml
+++ b/src/Osma.Mobile.App/Views/Connections/AcceptInvitePage.xaml
@@ -54,13 +54,13 @@
                     IsEnabled="{Binding IsBusy, Converter={StaticResource BooleanInverse}}"
                     Command="{Binding RejectInviteCommand}"
                     HorizontalOptions="FillAndExpand"
-                    Text="cancel"/>
+                    Text="Cancel"/>
                 <Button
                     HorizontalOptions="FillAndExpand"
                     Style="{DynamicResource BlueButtonStyle}"
                     IsEnabled="{Binding IsBusy, Converter={StaticResource BooleanInverse}}"
                     Command="{Binding AcceptInviteCommand}"
-                    Text="connect"/>
+                    Text="Connect"/>
             </StackLayout>
         </Grid>
     </ContentPage.Content>

--- a/src/Osma.Mobile.App/Views/Connections/AcceptInvitePage.xaml
+++ b/src/Osma.Mobile.App/Views/Connections/AcceptInvitePage.xaml
@@ -50,17 +50,17 @@
                 HorizontalOptions="FillAndExpand"
                 VerticalOptions="FillAndExpand">
                 <Button
-                    HorizontalOptions="FillAndExpand"
-                    Style="{DynamicResource BlueButtonStyle}"
-                    IsEnabled="{Binding IsBusy, Converter={StaticResource BooleanInverse}}"
-                    Command="{Binding AcceptInviteCommand}"
-                    Text="Trust"/>
-                <Button
                     Style="{DynamicResource RedButtonStyle}"
                     IsEnabled="{Binding IsBusy, Converter={StaticResource BooleanInverse}}"
                     Command="{Binding RejectInviteCommand}"
                     HorizontalOptions="FillAndExpand"
-                    Text="Dont trust"/>
+                    Text="cancel"/>
+                <Button
+                    HorizontalOptions="FillAndExpand"
+                    Style="{DynamicResource BlueButtonStyle}"
+                    IsEnabled="{Binding IsBusy, Converter={StaticResource BooleanInverse}}"
+                    Command="{Binding AcceptInviteCommand}"
+                    Text="connect"/>
             </StackLayout>
         </Grid>
     </ContentPage.Content>


### PR DESCRIPTION
#### Short description of what this resolves:
This PR changes "accept connection model" to display a description and moves the accept button to the right of the cancel button.

#### Changes proposed in this pull request:
- new accept connection button layout, with cancel on the left and accept on the right.
- new description for accepting a connection.