### PR TITLE
Comment out storage path for non-Android targets

### DIFF
--- a/src/Osma.Mobile.App.Services/AgentContextService.cs
+++ b/src/Osma.Mobile.App.Services/AgentContextService.cs
@@ -43,9 +43,10 @@ namespace Osma.Mobile.App.Services
         
         public async Task<bool> CreateAgentAsync(AgentOptions options)
         {
+#if __ANDROID__
             WalletConfiguration.WalletStorageConfiguration _storage = new WalletConfiguration.WalletStorageConfiguration { Path = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".indy_client") };
             options.WalletOptions.WalletConfiguration.StorageConfiguration = _storage;
-            
+#endif
             await _provisioningService.ProvisionAgentAsync(new ProvisioningConfiguration
             {
                 WalletConfiguration = options.WalletOptions.WalletConfiguration,


### PR DESCRIPTION
Removed the ability to set path manually for iOS, this is not required. Fixes #9 